### PR TITLE
Feature: Receive raw UDP h.264 streams

### DIFF
--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(AutoPilotPlugins
 
 	Generic/GenericAutoPilotPlugin.cc
 
+	Generic/RTKGPSComponent.cc
+
 	PX4/AirframeComponent.cc
 	PX4/AirframeComponentAirframes.cc
 	PX4/AirframeComponentController.cc

--- a/src/FirmwarePlugin/CMakeLists.txt
+++ b/src/FirmwarePlugin/CMakeLists.txt
@@ -17,6 +17,10 @@ add_library(FirmwarePlugin
 	PX4/PX4FirmwarePluginFactory.cc
 	PX4/PX4ParameterMetaData.cc
 	PX4/PX4Resources.qrc
+
+	ChargingStation/ChargingStationFirmwarePlugin.cc
+	ChargingStation/ChargingStationFirmwarePluginFactory.cc
+	ChargingStation/ChargingStationResources.qrc
 )
 
 target_link_libraries(FirmwarePlugin
@@ -27,6 +31,8 @@ target_link_libraries(FirmwarePlugin
 target_include_directories(FirmwarePlugin
 	INTERFACE
 		${CMAKE_CURRENT_SOURCE_DIR}
-                APM
+				APM
+				ChargingStation
+				PX4
 	)
 

--- a/src/FlightDisplay/VideoManager.cc
+++ b/src/FlightDisplay/VideoManager.cc
@@ -332,13 +332,15 @@ VideoManager::isGStreamer()
             videoSource == VideoSettings::videoSourceUDPH265 ||
             videoSource == VideoSettings::videoSourceRTSP ||
             videoSource == VideoSettings::videoSourceTCP ||
-            videoSource == VideoSettings::videoSourceMPEGTS)) ||
+            videoSource == VideoSettings::videoSourceMPEGTS ||
+            videoSource == VideoSettings::videoSourceUDP264RAW)) ||
         ((_activeVehicle && (csVehicleID == _activeVehicle->id()) &&
             (csVideoSource == VideoSettings::videoSourceUDPH264 ||
             csVideoSource == VideoSettings::videoSourceUDPH265 ||
             csVideoSource == VideoSettings::videoSourceRTSP ||
             csVideoSource == VideoSettings::videoSourceTCP ||
-            csVideoSource == VideoSettings::videoSourceMPEGTS))) ||
+            csVideoSource == VideoSettings::videoSourceMPEGTS ||
+            csVideoSource == VideoSettings::videoSourceUDP264RAW))) ||
         autoStreamConfigured();
 #else
     return false;
@@ -357,6 +359,7 @@ VideoManager::isVideoEnabled()
         videoSource == VideoSettings::videoSourceRTSP ||
         videoSource == VideoSettings::videoSourceTCP ||
         videoSource == VideoSettings::videoSourceMPEGTS ||
+        videoSource == VideoSettings::videoSourceUDP264RAW ||
         autoStreamConfigured();
 #else
     return false;
@@ -374,7 +377,8 @@ VideoManager::isCsVideoEnabled()
         csVideoSource == VideoSettings::videoSourceUDPH265 ||
         csVideoSource == VideoSettings::videoSourceRTSP ||
         csVideoSource == VideoSettings::videoSourceTCP ||
-        csVideoSource == VideoSettings::videoSourceMPEGTS;
+        csVideoSource == VideoSettings::videoSourceMPEGTS ||
+        csVideoSource == VideoSettings::videoSourceUDP264RAW;
 #else
     return false;
 #endif
@@ -460,6 +464,8 @@ VideoManager::_updateSettings()
             _videoReceiver->setUri(_videoSettings->rtspUrl()->rawValue().toString());
         else if (source == VideoSettings::videoSourceTCP)
             _videoReceiver->setUri(QStringLiteral("tcp://%1").arg(_videoSettings->tcpUrl()->rawValue().toString()));
+        else if (source == VideoSettings::videoSourceUDP264RAW)
+            _videoReceiver->setUri(QStringLiteral("udpraw://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
     } else {
         // Charging station video stream
         qCDebug(VideoManagerLog) << "Selecting Charging Station video stream";
@@ -474,6 +480,8 @@ VideoManager::_updateSettings()
             _videoReceiver->setUri(_videoSettings->csRtspUrl()->rawValue().toString());
         else if (source == VideoSettings::videoSourceTCP)
             _videoReceiver->setUri(QStringLiteral("tcp://%1").arg(_videoSettings->csTcpUrl()->rawValue().toString()));
+        else if (source == VideoSettings::videoSourceUDP264RAW)
+            _videoReceiver->setUri(QStringLiteral("udpraw://0.0.0.0:%1").arg(_videoSettings->csUdpPort()->rawValue().toInt()));
     }
 }
 

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -26,6 +26,7 @@ const char* VideoSettings::videoSourceUDPH264   = "UDP h.264 Video Stream";
 const char* VideoSettings::videoSourceUDPH265   = "UDP h.265 Video Stream";
 const char* VideoSettings::videoSourceTCP       = "TCP-MPEG2 Video Stream";
 const char* VideoSettings::videoSourceMPEGTS    = "MPEG-TS (h.264) Video Stream";
+const char* VideoSettings::videoSourceUDP264RAW = "Raw UDP h.264 Stream";
 
 DECLARE_SETTINGGROUP(Video, "Video")
 {
@@ -41,6 +42,9 @@ DECLARE_SETTINGGROUP(Video, "Video")
 #endif
     videoSourceList.append(videoSourceTCP);
     videoSourceList.append(videoSourceMPEGTS);
+#ifndef NO_UDP_VIDEO
+    videoSourceList.append(videoSourceUDP264RAW);
+#endif
 #endif
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
@@ -207,7 +211,7 @@ bool VideoSettings::streamConfigured(void)
         return false;
     }
     //-- If UDP, check if port is set
-    if(vSource == videoSourceUDPH264 || vSource == videoSourceUDPH265) {
+    if(vSource == videoSourceUDPH264 || vSource == videoSourceUDPH265 || vSource == videoSourceUDP264RAW) {
         qCDebug(VideoManagerLog) << "Testing configuration for UDP Stream:" << udpPort()->rawValue().toInt();
         return udpPort()->rawValue().toInt() != 0;
     }
@@ -245,7 +249,7 @@ bool VideoSettings::csStreamConfigured(void)
         return false;
     }
     //-- If UDP, check if port is set
-    if(vSource == videoSourceUDPH264 || vSource == videoSourceUDPH265) {
+    if(vSource == videoSourceUDPH264 || vSource == videoSourceUDPH265 || vSource == videoSourceUDP264RAW) {
         qCDebug(VideoManagerLog) << "Testing configuration for UDP Stream:" << csUdpPort()->rawValue().toInt();
         return csUdpPort()->rawValue().toInt() != 0;
     }

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -57,6 +57,7 @@ public:
     Q_PROPERTY(QString  udp265VideoSource       READ udp265VideoSource      CONSTANT)
     Q_PROPERTY(QString  tcpVideoSource          READ tcpVideoSource         CONSTANT)
     Q_PROPERTY(QString  mpegtsVideoSource       READ mpegtsVideoSource      CONSTANT)
+    Q_PROPERTY(QString  udp264RawVideoSource    READ udp264RawVideoSource   CONSTANT)
 
     bool     streamConfigured       ();
     bool     csStreamConfigured     ();
@@ -65,6 +66,7 @@ public:
     QString  udp265VideoSource      () { return videoSourceUDPH265; }
     QString  tcpVideoSource         () { return videoSourceTCP; }
     QString  mpegtsVideoSource      () { return videoSourceMPEGTS; }
+    QString  udp264RawVideoSource   () { return videoSourceUDP264RAW; }
 
     static const char* videoSourceNoVideo;
     static const char* videoDisabled;
@@ -73,6 +75,7 @@ public:
     static const char* videoSourceRTSP;
     static const char* videoSourceTCP;
     static const char* videoSourceMPEGTS;
+    static const char* videoSourceUDP264RAW;
 
 signals:
     void streamConfiguredChanged    ();

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -53,12 +53,14 @@ Rectangle {
     property bool   _isRTSP:                    _isVideoEnabled && _videoSource === QGroundControl.settingsManager.videoSettings.rtspVideoSource
     property bool   _isTCP:                     _isVideoEnabled && _videoSource === QGroundControl.settingsManager.videoSettings.tcpVideoSource
     property bool   _isMPEGTS:                  _isVideoEnabled && _videoSource === QGroundControl.settingsManager.videoSettings.mpegtsVideoSource
+    property bool   _isUDP264RAW:               _isVideoEnabled && _videoSource === QGroundControl.settingsManager.videoSettings.udp264RawVideoSource
     property bool   _isCsVideoEnabled:          QGroundControl.videoManager.isCsVideoEnabled
     property bool   _isCsUDP264:                _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.udp264VideoSource
     property bool   _isCsUDP265:                _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.udp265VideoSource
     property bool   _isCsRTSP:                  _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.rtspVideoSource
     property bool   _isCsTCP:                   _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.tcpVideoSource
     property bool   _isCsMPEGTS:                _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.mpegtsVideoSource
+    property bool   _isCsUDP264RAW:             _isCsVideoEnabled && _csVideoSource === QGroundControl.settingsManager.videoSettings.udp264RawVideoSource
 
     property string gpsDisabled: "Disabled"
     property string gpsUdpPort:  "UDP Port"
@@ -810,12 +812,12 @@ Rectangle {
 
                             QGCLabel {
                                 text:                   qsTr("UDP Port")
-                                visible:                (_isUDP264 || _isUDP265 || _isMPEGTS)  && QGroundControl.settingsManager.videoSettings.udpPort.visible
+                                visible:                (_isUDP264 || _isUDP265 || _isMPEGTS || _isUDP264RAW)  && QGroundControl.settingsManager.videoSettings.udpPort.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
                                 fact:                   QGroundControl.settingsManager.videoSettings.udpPort
-                                visible:                (_isUDP264 || _isUDP265 || _isMPEGTS) && QGroundControl.settingsManager.videoSettings.udpPort.visible
+                                visible:                (_isUDP264 || _isUDP265 || _isMPEGTS || _isUDP264RAW) && QGroundControl.settingsManager.videoSettings.udpPort.visible
                             }
 
                             QGCLabel {
@@ -905,12 +907,12 @@ Rectangle {
 
                             QGCLabel {
                                 text:                   qsTr("UDP Port")
-                                visible:                (_isCsUDP264 || _isCsUDP265 || _isCsMPEGTS)  && QGroundControl.settingsManager.videoSettings.csUdpPort.visible
+                                visible:                (_isCsUDP264 || _isCsUDP265 || _isCsMPEGTS || _isCsUDP264RAW)  && QGroundControl.settingsManager.videoSettings.csUdpPort.visible
                             }
                             FactTextField {
                                 Layout.preferredWidth:  _comboFieldWidth
                                 fact:                   QGroundControl.settingsManager.videoSettings.udpPort
-                                visible:                (_isCsUDP264 || _isCsUDP265 || _isCsMPEGTS) && QGroundControl.settingsManager.videoSettings.csUdpPort.visible
+                                visible:                (_isCsUDP264 || _isCsUDP265 || _isCsMPEGTS || _isCsUDP264RAW) && QGroundControl.settingsManager.videoSettings.csUdpPort.visible
                             }
 
                             QGCLabel {


### PR DESCRIPTION
This P/R adds the ability to receive raw (non-RTP, non-MPEGTS) h.264 streams transmitted over UDP, for drone video feed as well as the charging station feed. This makes the stream more susceptible to packet loss and transmission errors, but should reduce latency.

Senders may use raw output from `raspivid` or other tools that provide UDP streaming functionality.

Sample `raspivid` invocation (sender side):

```bash
raspivid -w 1280 -h 720 -t 0 -g 1 -t 0 -o udp://<HOST_WITH_QGC_RUNNING>:5600
```

Note that QGC must be running before `raspivid` invocation; otherwise it will fail, being unable to write to a socket.

Sample gstreamer pipeline (for local video):

```bash
gst-launch-1.0 v4l2src ! video/x-raw,width=640,height=480,framerate=30/1 ! videoconvert ! video/x-raw,format=I420 ! x264enc speed-preset=ultrafast tune=zerolatency ! udpsink host=127.0.0.1 port=5600
```